### PR TITLE
Add memory=single_bit blacklist on a per-DIMM basis

### DIFF
--- a/check_openmanage
+++ b/check_openmanage
@@ -3251,8 +3251,12 @@ sub check_memory {
 		  $index, $location, $size, $status;
 	    }
 	    else {
+		my $failures = join(q{, }, @failures);
+		if (index($failures, 'Single-bit failure error rate exceeded') != -1) {
+			next DIMM if blacklisted('memory', 'single_bit');
+                }
 		$msg = sprintf 'Memory module %d [%s, %s]: %s',
-		  $index, $location, $size, (join q{, }, @failures);
+		  $index, $location, $size, $failures;
 	    }
 
 	    report('chassis', $msg, $status2nagios{$status}, $index);


### PR DESCRIPTION
This introduces a new type of blacklist for the memory module to ignore single-bit memory errors. The use of ECC means corrected single-bit errors are often irrelevant so this allows us to ignore them since they're not indicative of an underlying problem.